### PR TITLE
Added pending EN tests and refactored tests to use fluent

### DIFF
--- a/test/scenarios/HmrcErrorNotificationOutbound/EN-2.js
+++ b/test/scenarios/HmrcErrorNotificationOutbound/EN-2.js
@@ -1,3 +1,30 @@
 describe('BTMS receives a ClearanceRequest with no EntryVersionNumber - EN-2', function () {
-  it.skip('', async function () {})
+  it('', async function () {
+    this.timeout(70000)
+
+    // Arrange: Set up test data
+    this.documentCode = 'C640'
+    this.correlationId = Math.floor(Math.random() * 1e12)
+
+    await newFluentClearanceRequestTest()
+      .addItem({
+        TaricCommodityCode: '0103911000',
+        Documents: [
+          {
+            DocumentCode: this.documentCode,
+            DocumentReference: generateDocumentReference()
+          }
+        ],
+        Checks: [{ CheckCode: 'H223', DepartmentCode: 'PHA' }]
+      })
+      .withEntryVersionNumber(null)
+      .withCorrelationId(this.correlationId)
+      .sendFluent()
+      .expectError({
+        code: 'ALVSVAL153',
+        messageTemplate:
+          'EntryVersionNumber has not been provided for the import document. Provide an EntryVersionNumber. Your request with correlation ID {correlationId} has been terminated.',
+        params: { correlationId: this.correlationId }
+      })
+  })
 })

--- a/test/scenarios/HmrcErrorNotificationOutbound/EN-3.js
+++ b/test/scenarios/HmrcErrorNotificationOutbound/EN-3.js
@@ -1,35 +1,23 @@
 describe('BTMS receives a ClearanceRequest where the DocumentCode does not map to the CheckCode - EN-3', function () {
   it('', async function () {
     this.timeout(70000)
-    testLogger.info('Send Clearance Request')
-    const builder = new SoapMessageBuilder()
 
+    // Arrange: Set up test data
     this.documentCode = 'C640'
-    builder.addItem({
-      TaricCommodityCode: '0103911000',
-      Documents: [
-        {
-          DocumentCode: this.documentCode,
-          DocumentReference: generateDocumentReference()
-        }
-      ],
-      Checks: [{ CheckCode: 'H223', DepartmentCode: 'PHA' }]
-    })
+    this.expectedError = `Document code ${this.documentCode} is not appropriate for the check code requested on ItemNumber 1`
 
-    this.mrn = generateRandomMRN()
-    const soapEnvelope = builder.buildMessage({
-      mrn: this.mrn
-    })
-    testLogger.info(soapEnvelope)
-
-    await sendSoapRequest(SUBMIT_CLEARANCE_REQUEST_ENDPOINT, soapEnvelope)
-
-    const responseText = await waitForDataInAPI(this.mrn, 'ERROR')
-    assert.ok(
-      responseText.includes(
-        `Document code ${this.documentCode} is not appropriate for the check code requested on ItemNumber 1`
-      ),
-      'Expected wrong Department Code error'
-    )
+    await newFluentClearanceRequestTest()
+      .addItem({
+        TaricCommodityCode: '0103911000',
+        Documents: [
+          {
+            DocumentCode: this.documentCode,
+            DocumentReference: generateDocumentReference()
+          }
+        ],
+        Checks: [{ CheckCode: 'H223', DepartmentCode: 'PHA' }]
+      })
+      .sendFluent()
+      .expectError(this.expectedError, 'Expected wrong Department Code error')
   })
 })

--- a/test/scenarios/HmrcErrorNotificationOutbound/EN-4.js
+++ b/test/scenarios/HmrcErrorNotificationOutbound/EN-4.js
@@ -1,41 +1,33 @@
 describe('BTMS receives a duplicate ClearanceRequest (same MRN, EntryVersionNumber, PreviousVersionNumber) - EN-4', function () {
   it('should handle duplicate ClearanceRequest correctly', async function () {
     this.timeout(70000)
-    // Send Clearance Request
-    const builder1 = new SoapMessageBuilder()
+
+    // Arrange: Set up test data
     this.docRef = generateDocumentReference()
-    builder1.addItem({
-      TaricCommodityCode: '0103911000',
-      Documents: [{ DocumentCode: 'C640', DocumentReference: this.docRef }],
-      Checks: [{ CheckCode: 'H221', DepartmentCode: 'AHVLA' }]
-    })
     this.mrn = generateRandomMRN()
-    const soapEnvelope1 = builder1.buildMessage({
-      mrn: this.mrn
-    })
-    testLogger.info(soapEnvelope1)
-    await sendSoapRequest(SUBMIT_CLEARANCE_REQUEST_ENDPOINT, soapEnvelope1)
+    this.expectedError = `There is already a current import declaration in BTMS with EntryReference ${this.mrn}`
 
-    // Send the same Clearance Request again
-    const builder2 = new SoapMessageBuilder()
-    builder2.addItem({
-      TaricCommodityCode: '0103911000',
-      Documents: [{ DocumentCode: 'C640', DocumentReference: this.docRef }],
-      Checks: [{ CheckCode: 'H221', DepartmentCode: 'AHVLA' }]
-    })
-    const soapEnvelope2 = builder2.buildMessage({
-      mrn: this.mrn
-    })
-    testLogger.info(soapEnvelope2)
-    await sendSoapRequest(SUBMIT_CLEARANCE_REQUEST_ENDPOINT, soapEnvelope2)
+    // Act: Send first clearance request
+    await newFluentClearanceRequestTest()
+      .addItem({
+        TaricCommodityCode: '0103911000',
+        Documents: [{ DocumentCode: 'C640', DocumentReference: this.docRef }],
+        Checks: [{ CheckCode: 'H221', DepartmentCode: 'AHVLA' }]
+      })
+      .withMRN(this.mrn)
+      .sendClearanceRequest()
 
-    // Wait for error to be logged
-    const responseText = await waitForDataInAPI(this.mrn, 'ERROR')
-    assert.ok(
-      responseText.includes(
-        `There is already a current import declaration in BTMS with EntryReference ${this.mrn}`
-      ),
-      'Expected duplicate mrn/EntryRefernce error'
-    )
+    await newFluentClearanceRequestTest()
+      .addItem({
+        TaricCommodityCode: '0103911000',
+        Documents: [{ DocumentCode: 'C640', DocumentReference: this.docRef }],
+        Checks: [{ CheckCode: 'H221', DepartmentCode: 'AHVLA' }]
+      })
+      .withMRN(this.mrn)
+      .sendFluent()
+      .expectError(
+        this.expectedError,
+        'Expected duplicate mrn/EntryRefernce error'
+      )
   })
 })

--- a/test/scenarios/HmrcErrorNotificationOutbound/EN-5.js
+++ b/test/scenarios/HmrcErrorNotificationOutbound/EN-5.js
@@ -1,5 +1,91 @@
 describe('BTMS receives a FinalisationNotification for an MRN which is already cancelled - EN-5', function () {
-  it.skip('', async function () {
+  it('should handle finalisation notification for already cancelled MRN', async function () {
     this.timeout(70000)
+
+    this.docRef = generateDocumentReference()
+    this.mrn = generateRandomMRN()
+
+    testLogger.info('Send initial IPAFFS notification')
+    await sendIpaffsMessage(
+      loadIPAFFSJson('CHEDA.json', {
+        referenceNumber: this.docRef,
+        lastUpdated: new Date().toISOString(),
+        partTwo: {
+          decision: { consignmentAcceptable: false },
+          inspectionRequired: 'Not required'
+        }
+      })
+    )
+
+    testLogger.info('Send Clearance Request')
+    await newFluentClearanceRequestTest()
+      .addItem({
+        TaricCommodityCode: '0103911000',
+        ItemNumber: 1,
+        Documents: [{ DocumentCode: 'C640', DocumentReference: this.docRef }],
+        Checks: [{ CheckCode: 'H221', DepartmentCode: 'AHVLA' }]
+      })
+      .addItem({
+        ItemNumber: 75,
+        TaricCommodityCode: '0103911001',
+        Documents: [
+          {
+            DocumentCode: 'C640',
+            DocumentReference: generateDocumentReference()
+          }
+        ],
+        Checks: [{ CheckCode: 'H221', DepartmentCode: 'AHVLA' }]
+      })
+      .withMRN(this.mrn)
+      .withEntryVersionNumber(1)
+      .sendClearanceRequest()
+      .then((test) => test.waitForDecision('H01'))
+
+    testLogger.info('Received decision with expected code H01')
+
+    testLogger.info(
+      'Send updated IPAFFS notification with decision (to release) and wait for C03'
+    )
+    await sendIpaffsMessage(
+      loadIPAFFSJson('CHEDA.json', {
+        referenceNumber: this.docRef,
+        lastUpdated: new Date().toISOString(),
+        version: 2,
+        status: 'VALIDATED',
+        partTwo: {
+          decision: {
+            consignmentAcceptable: true,
+            decision: 'Acceptable for Internal Market'
+          },
+          inspectionRequired: 'Not required'
+        }
+      })
+    ).then(() => waitForDecision(this.mrn, 'C03'))
+
+    testLogger.info('Received decision with expected code C03')
+
+    testLogger.info('Send cancellation')
+    let responseText = await newFluentFinalisationTest()
+      .withMRN(this.mrn)
+      .withEntryVersionNumber(1)
+      .withFinalState('1')
+      .withDecisionNumber(2)
+      .withManualAction('N')
+      .sendFinalisation()
+      .then((test) => test.expectFinalisationState('1'))
+
+    testLogger.info('Cancellation response:', { responseText })
+
+    testLogger.info('Send finalisation')
+    responseText = await newFluentFinalisationTest()
+      .withMRN(this.mrn)
+      .withEntryVersionNumber(1)
+      .withFinalState('0')
+      .withDecisionNumber(3)
+      .withManualAction('Y')
+      .sendFinalisation()
+      .then((test) => test.expectFinalisationState('1', 15000))
+
+    testLogger.info('Finalisation response:', { responseText })
   })
 })

--- a/test/scenarios/HmrcErrorNotificationOutbound/EN-6.js
+++ b/test/scenarios/HmrcErrorNotificationOutbound/EN-6.js
@@ -1,11 +1,14 @@
 describe('BTMS receives a ClearanceRequest with many items. One item does not have a DocumentCode, a different item does not have CheckCode. - EN-6', function () {
-  it('', async function () {
+  it('should handle multiple validation errors correctly', async function () {
     this.timeout(70000)
-    testLogger.info('Send Clearance Request')
-    const builder = new SoapMessageBuilder()
 
+    // Arrange: Set up test data
     this.documentCode = 'C640'
-    builder
+    this.docRef = generateDocumentReference()
+    this.mrn = generateRandomMRN()
+
+    // Act & Assert: Send clearance request with validation errors and expect multiple errors using fluent API
+    await newFluentClearanceRequestTest()
       .addItem({
         TaricCommodityCode: '0103911000',
         Documents: [
@@ -25,76 +28,47 @@ describe('BTMS receives a ClearanceRequest with many items. One item does not ha
         ],
         Checks: [{ CheckCode: null, DepartmentCode: 'AHVLA' }]
       })
-
-    this.mrn = generateRandomMRN()
-    const soapEnvelope = builder.buildMessage({
-      mrn: this.mrn
-    })
-    testLogger.info(soapEnvelope)
-
-    await sendSoapRequest(SUBMIT_CLEARANCE_REQUEST_ENDPOINT, soapEnvelope)
-
-    const responseText = await waitForDataInAPI(this.mrn, 'ERROR')
-
-    const responseObj = JSON.parse(responseText)
-
-    const notifications = responseObj.processingErrors
-    assert(
-      Array.isArray(notifications) && notifications.length > 0,
-      'No notifications found'
-    )
-
-    const errors = notifications[0].errors
-    assert(Array.isArray(errors), 'Errors field missing or not an array')
-
-    function assertErrorWithParams(code, messageTemplate, params) {
-      const expectedSubstring = messageTemplate.replace(
-        /\{(\w+)\}/g,
-        (_, key) => {
-          return params[key] !== undefined ? params[key] : `{${key}}`
+      .withMRN(this.mrn)
+      .sendFluent()
+      .expectMultipleErrors([
+        // Item 2 errors (missing DocumentCode)
+        {
+          code: 'ALVSVAL308',
+          messageTemplate:
+            'DocumentCode {documentCode} on item number {itemNumber} is invalid',
+          params: { itemNumber: 2, documentCode: '' }
+        },
+        {
+          code: 'ALVSVAL320',
+          messageTemplate:
+            'Document code {documentCode} is not appropriate for the check code requested on ItemNumber {itemNumber}',
+          params: { itemNumber: 2, documentCode: '' }
+        },
+        {
+          code: 'ALVSVAL321',
+          messageTemplate:
+            'Check code {checkCode} on ItemNumber {itemNumber} must have a document code',
+          params: { itemNumber: 2, checkCode: 'H221' }
+        },
+        // Item 3 errors (missing CheckCode)
+        {
+          code: 'ALVSVAL311',
+          messageTemplate:
+            'The CheckCode field on item number {itemNumber} must have a value',
+          params: { itemNumber: 3 }
+        },
+        {
+          code: 'ALVSVAL320',
+          messageTemplate:
+            'Document code {documentCode} is not appropriate for the check code requested on ItemNumber {itemNumber}',
+          params: { itemNumber: 3, documentCode: 'C640' }
+        },
+        {
+          code: 'ALVSVAL321',
+          messageTemplate:
+            'Check code {checkCode} on ItemNumber {itemNumber} must have a document code',
+          params: { itemNumber: 3, checkCode: '' }
         }
-      )
-
-      const found = errors.find(
-        (e) => e.code === code && e.message.includes(expectedSubstring)
-      )
-      assert(
-        found,
-        `Expected error with code ${code} and message containing "${expectedSubstring}"`
-      )
-    }
-
-    assertErrorWithParams(
-      'ALVSVAL308',
-      'DocumentCode {documentCode} on item number {itemNumber} is invalid',
-      { itemNumber: 2, documentCode: '' }
-    )
-    assertErrorWithParams(
-      'ALVSVAL320',
-      'Document code {documentCode} is not appropriate for the check code requested on ItemNumber {itemNumber}',
-      { itemNumber: 2, documentCode: '' }
-    )
-    assertErrorWithParams(
-      'ALVSVAL321',
-      'Check code {checkCode} on ItemNumber {itemNumber} must have a document code',
-      { itemNumber: 2, checkCode: 'H221' }
-    )
-
-    // Item 3
-    assertErrorWithParams(
-      'ALVSVAL311',
-      'The CheckCode field on item number {itemNumber} must have a value',
-      { itemNumber: 3 }
-    )
-    assertErrorWithParams(
-      'ALVSVAL320',
-      'Document code {documentCode} is not appropriate for the check code requested on ItemNumber {itemNumber}',
-      { itemNumber: 3, documentCode: 'C640' }
-    )
-    assertErrorWithParams(
-      'ALVSVAL321',
-      'Check code {checkCode} on ItemNumber {itemNumber} must have a document code',
-      { itemNumber: 3, checkCode: '' }
-    )
+      ])
   })
 })

--- a/test/steps/cds/inbound/clearanceRequest.js
+++ b/test/steps/cds/inbound/clearanceRequest.js
@@ -1,4 +1,5 @@
 import { SoapMessageBuilder } from '#utils/soapMessageBuilder.js'
+import { waitForDataInAPI } from '#utils/tradeimportsdatapiMessageHandler.js'
 
 export async function sendClearanceRequest(clearanceRequest) {
   globalThis.testLogger.info('Sending ClearanceRequest')
@@ -8,4 +9,405 @@ export async function sendClearanceRequest(clearanceRequest) {
 
 export function newClearanceRequest() {
   return new SoapMessageBuilder()
+}
+
+export async function expectErrorResponse(
+  mrn,
+  expectedErrorPattern,
+  customErrorMessage = null
+) {
+  const responseText = await waitForDataInAPI(mrn, 'ERROR')
+  const defaultMessage = `Expected error message containing: '${expectedErrorPattern}'`
+  const errorMessage = customErrorMessage || defaultMessage
+
+  globalThis.assert.ok(
+    responseText.includes(expectedErrorPattern),
+    errorMessage
+  )
+  return responseText
+}
+
+// Enhanced fluent API for complete test workflows
+export class ClearanceRequestTestBuilder {
+  constructor() {
+    this.builder = new SoapMessageBuilder()
+    this.mrn = null
+    this.sent = false
+  }
+
+  withCommodity(taricCode, overrides = {}) {
+    this.builder.withCommodity(taricCode, overrides)
+    return this
+  }
+
+  withDocument(documentCode, documentReference, overrides = {}) {
+    this.builder.withDocument(documentCode, documentReference, overrides)
+    return this
+  }
+
+  withOnlyDocument(documentCode, documentReference, overrides = {}) {
+    this.builder.withOnlyDocument(documentCode, documentReference, overrides)
+    return this
+  }
+
+  withCheck(checkCode, departmentCode, overrides = {}) {
+    this.builder.withCheck(checkCode, departmentCode, overrides)
+    return this
+  }
+
+  withMRN(mrn) {
+    this.mrn = mrn
+    this.builder.withMRN(mrn)
+    return this
+  }
+
+  withEntryVersionNumber(entryVersionNumber) {
+    this.builder.withEntryVersionNumber(entryVersionNumber)
+    return this
+  }
+
+  addItem(overrides = {}) {
+    this.builder.addItem(overrides)
+    return this
+  }
+
+  withCorrelationId(correlationId) {
+    this.builder.withCorrelationId(correlationId)
+    return this
+  }
+
+  async sendClearanceRequest() {
+    if (!this.mrn) {
+      this.mrn = globalThis.generateRandomMRN()
+      this.builder.withMRN(this.mrn)
+    }
+
+    const soapEnvelope = this.builder.buildModel().buildMessage()
+    await sendClearanceRequest(soapEnvelope)
+    this.sent = true
+    return this
+  }
+
+  async waitForDecision(expectedDecisionCode) {
+    if (!this.sent) {
+      throw new Error(
+        'Must call sendClearanceRequest() before waitForDecision()'
+      )
+    }
+
+    const decisionXml = await globalThis.waitForSpecificDecision(
+      this.mrn,
+      expectedDecisionCode
+    )
+    const codes = await globalThis.extractDecisionCodes(decisionXml)
+    globalThis.testLogger.info('Received decision codes:', {
+      decisionCodes: codes
+    })
+    return decisionXml
+  }
+
+  async expectErrorResponse(expectedErrorPattern, customErrorMessage = null) {
+    if (!this.sent) {
+      throw new Error(
+        'Must call sendClearanceRequest() before expectErrorResponse()'
+      )
+    }
+    return await expectErrorResponse(
+      this.mrn,
+      expectedErrorPattern,
+      customErrorMessage
+    )
+  }
+
+  async expectDecision(expectedDecisionCode) {
+    if (!this.sent) {
+      throw new Error(
+        'Must call sendClearanceRequest() before expectDecision()'
+      )
+    }
+    const decisionXml = await globalThis.waitForSpecificDecision(
+      this.mrn,
+      expectedDecisionCode
+    )
+    const codes = await globalThis.extractDecisionCodes(decisionXml)
+    globalThis.testLogger.info('Received decision codes:', {
+      decisionCodes: codes
+    })
+    return decisionXml
+  }
+
+  getMrn() {
+    return this.mrn
+  }
+}
+
+// Fluent API that handles the entire test workflow
+export class FluentClearanceRequestTest {
+  constructor() {
+    this.builder = new ClearanceRequestTestBuilder()
+  }
+
+  withCommodity(taricCode, overrides = {}) {
+    this.builder.withCommodity(taricCode, overrides)
+    return this
+  }
+
+  withDocument(documentCode, documentReference, overrides = {}) {
+    this.builder.withDocument(documentCode, documentReference, overrides)
+    return this
+  }
+
+  withOnlyDocument(documentCode, documentReference, overrides = {}) {
+    this.builder.withOnlyDocument(documentCode, documentReference, overrides)
+    return this
+  }
+
+  withCheck(checkCode, departmentCode, overrides = {}) {
+    this.builder.withCheck(checkCode, departmentCode, overrides)
+    return this
+  }
+
+  withMRN(mrn) {
+    this.builder.withMRN(mrn)
+    return this
+  }
+
+  withEntryVersionNumber(entryVersionNumber) {
+    this.builder.withEntryVersionNumber(entryVersionNumber)
+    return this
+  }
+
+  addItem(overrides = {}) {
+    this.builder.addItem(overrides)
+    return this
+  }
+
+  withCorrelationId(correlationId) {
+    this.builder.withCorrelationId(correlationId)
+    return this
+  }
+
+  // Method that handles the complete workflow: send + expect error
+  async sendAndExpectError(expectedErrorPattern) {
+    await this.builder.sendClearanceRequest()
+    return await this.builder.expectErrorResponse(expectedErrorPattern)
+  }
+
+  // Method that handles the complete workflow: send + expect decision
+  async sendAndExpectDecision(expectedDecisionCode) {
+    await this.builder.sendClearanceRequest()
+    return await this.builder.expectDecision(expectedDecisionCode)
+  }
+
+  // Individual methods for when you need more control
+  async sendClearanceRequest() {
+    await this.builder.sendClearanceRequest()
+    return this
+  }
+
+  async expectErrorResponse(expectedErrorPattern, customErrorMessage = null) {
+    if (typeof expectedErrorPattern === 'string') {
+      await this.builder.expectErrorResponse(
+        expectedErrorPattern,
+        customErrorMessage
+      )
+    } else if (
+      typeof expectedErrorPattern === 'object' &&
+      expectedErrorPattern.code
+    ) {
+      // Handle structured error validation
+      await this.expectMultipleErrors([expectedErrorPattern])
+    } else {
+      throw new Error(
+        'expectErrorResponse expects either a string pattern or an error object with code, messageTemplate, and params'
+      )
+    }
+    return this
+  }
+
+  async expectDecision(expectedDecisionCode) {
+    await this.builder.expectDecision(expectedDecisionCode)
+    return this
+  }
+
+  async waitForDecision(expectedDecisionCode) {
+    await this.builder.waitForDecision(expectedDecisionCode)
+    return this
+  }
+
+  getMrn() {
+    return this.builder.getMrn()
+  }
+
+  // Fluent interface for async operations
+  sendFluent() {
+    return {
+      send: () => this.sendClearanceRequest(),
+      expectError: (expectedErrorPattern) =>
+        this.sendClearanceRequest().then(() =>
+          this.expectErrorResponse(expectedErrorPattern)
+        ),
+      expectDecision: (expectedDecisionCode) =>
+        this.sendClearanceRequest().then(() =>
+          this.expectDecision(expectedDecisionCode)
+        ),
+      expectMultipleErrors: (errorValidations) =>
+        this.sendClearanceRequest().then(() =>
+          this.expectMultipleErrors(errorValidations)
+        )
+    }
+  }
+
+  async expectMultipleErrors(errorValidations) {
+    const responseText = await waitForDataInAPI(this.builder.getMrn(), 'ERROR')
+    const responseObj = JSON.parse(responseText)
+
+    const notifications = responseObj.processingErrors
+    assert(
+      Array.isArray(notifications) && notifications.length > 0,
+      'No notifications found'
+    )
+
+    const errors = notifications[0].errors
+    assert(Array.isArray(errors), 'Errors field missing or not an array')
+
+    function assertErrorWithParams(
+      code,
+      messageTemplate,
+      params,
+      customErrorMessage = null
+    ) {
+      const expectedSubstring = messageTemplate.replace(
+        /\{(\w+)\}/g,
+        (_, key) => {
+          return params[key] !== undefined ? params[key] : `{${key}}`
+        }
+      )
+
+      const found = errors.find(
+        (e) => e.code === code && e.message.includes(expectedSubstring)
+      )
+
+      const defaultMessage = `Expected error with code ${code} and message containing '${expectedSubstring}'`
+      const errorMessage = customErrorMessage || defaultMessage
+
+      assert(found, errorMessage)
+    }
+
+    // Validate each error
+    errorValidations.forEach((validation) => {
+      assertErrorWithParams(
+        validation.code,
+        validation.messageTemplate,
+        validation.params,
+        validation.customErrorMessage
+      )
+    })
+
+    return this
+  }
+}
+
+export function newClearanceRequestTest() {
+  return new ClearanceRequestTestBuilder()
+}
+
+export function newFluentClearanceRequestTest() {
+  return new FluentClearanceRequestTest()
+}
+
+// Fluent API for finalisation messages
+export class FluentFinalisationTest {
+  constructor() {
+    this.builder = new SoapMessageBuilder('finalisation')
+    this.mrn = null
+    this.sent = false
+  }
+
+  withMRN(mrn) {
+    this.mrn = mrn
+    this.builder.withMRN(mrn)
+    return this
+  }
+
+  withEntryVersionNumber(entryVersionNumber) {
+    this._entryVersionNumber = entryVersionNumber
+    return this
+  }
+
+  withFinalState(finalState) {
+    this._finalState = finalState
+    return this
+  }
+
+  withDecisionNumber(decisionNumber) {
+    this._decisionNumber = decisionNumber
+    return this
+  }
+
+  withManualAction(manualAction) {
+    this._manualAction = manualAction
+    return this
+  }
+
+  async sendFinalisation() {
+    const soapEnvelope = this.builder.buildMessage({
+      EntryReference: this.mrn,
+      EntryVersionNumber: this._entryVersionNumber || 1,
+      FinalState: this._finalState,
+      DecisionNumber: this._decisionNumber,
+      ManualAction: this._manualAction
+    })
+
+    testLogger.info(soapEnvelope)
+    await sendSoapRequest(SUBMIT_FINALSIATION_ENDPOINT, soapEnvelope)
+    this.sent = true
+    return this
+  }
+
+  async expectFinalisationState(expectedState, stabilityDuration = 0) {
+    if (!this.sent) {
+      throw new Error(
+        'Must call sendFinalisation() before expectFinalisationState()'
+      )
+    }
+
+    if (stabilityDuration > 0) {
+      return await waitForDataInAPIWithStability(
+        this.mrn,
+        '',
+        {
+          finalisation: { finalState: expectedState }
+        },
+        stabilityDuration
+      )
+    } else {
+      return await waitForDataInAPI(this.mrn, '', {
+        finalisation: { finalState: expectedState }
+      })
+    }
+  }
+}
+
+export function newFluentFinalisationTest() {
+  return new FluentFinalisationTest()
+}
+
+// Standalone function for waiting for decisions
+export async function waitForDecision(mrn, expectedDecisionCode) {
+  const decisionXml = await globalThis.waitForSpecificDecision(
+    mrn,
+    expectedDecisionCode
+  )
+  const codes = await globalThis.extractDecisionCodes(decisionXml)
+  globalThis.testLogger.info('Received decision codes:', {
+    decisionCodes: codes
+  })
+  return decisionXml
+}
+
+// Helper function for true fluent chaining with async methods
+export async function executeClearanceRequestTest(testBuilder) {
+  await testBuilder.sendClearanceRequest()
+  return testBuilder
 }

--- a/test/steps/steps.js
+++ b/test/steps/steps.js
@@ -1,7 +1,19 @@
 import {
   newClearanceRequest,
-  sendClearanceRequest
+  sendClearanceRequest,
+  expectErrorResponse,
+  newClearanceRequestTest,
+  newFluentClearanceRequestTest,
+  newFluentFinalisationTest,
+  waitForDecision,
+  executeClearanceRequestTest
 } from '#steps/cds/inbound/clearanceRequest.js'
 
 globalThis.newClearanceRequest = newClearanceRequest
 globalThis.sendClearanceRequest = sendClearanceRequest
+globalThis.expectErrorResponse = expectErrorResponse
+globalThis.newClearanceRequestTest = newClearanceRequestTest
+globalThis.newFluentClearanceRequestTest = newFluentClearanceRequestTest
+globalThis.newFluentFinalisationTest = newFluentFinalisationTest
+globalThis.waitForDecision = waitForDecision
+globalThis.executeClearanceRequestTest = executeClearanceRequestTest

--- a/test/utils/soapMessageBuilder.js
+++ b/test/utils/soapMessageBuilder.js
@@ -1,8 +1,8 @@
 import Handlebars from 'handlebars'
 import {
   clearanceRequestTemplate,
-  finalisationNotificationTemplate,
-  errorNotificationTemplate
+  errorNotificationTemplate,
+  finalisationNotificationTemplate
 } from './soapTemplates.js'
 
 function generateRandomMRN() {
@@ -100,6 +100,16 @@ export class SoapMessageBuilder {
     if (this.templateType === 'clearance') {
       baseData.items = this.items
 
+      // Override EntryVersionNumber if explicitly set
+      if (this._entryVersionNumber !== undefined) {
+        baseData.EntryVersionNumber = this._entryVersionNumber
+      }
+
+      // Override CorrelationId if explicitly set
+      if (this._correlationId !== undefined) {
+        baseData.CorrelationId = this._correlationId
+      }
+
       if (baseData.PreviousVersionNumber == null) {
         const entryVersion = baseData.EntryVersionNumber
         if (entryVersion > 1) {
@@ -108,7 +118,10 @@ export class SoapMessageBuilder {
       }
     }
 
-    this._model = baseData
+    // Remove null values from the model to exclude them from the payload
+    this._model = Object.fromEntries(
+      Object.entries(baseData).filter(([_, value]) => value !== null)
+    )
     return this
   }
 
@@ -183,5 +196,121 @@ export class SoapMessageBuilder {
     const template = Handlebars.compile(templates[this.templateType])
     const fullData = this.buildModel(overrides)._model
     return template(fullData)
+  }
+
+  // Fluent builder methods for better readability
+  withDocument(documentCode, documentReference, overrides = {}) {
+    if (this.templateType !== 'clearance') {
+      throw new Error(`withDocument is only supported for clearance requests`)
+    }
+
+    const document = {
+      DocumentCode: documentCode,
+      DocumentReference: documentReference,
+      ...overrides
+    }
+
+    // Add to the last item if it exists, otherwise create a new item
+    if (this.items.length === 0) {
+      this.addItem({ Documents: [document] })
+    } else {
+      const lastItem = this.items[this.items.length - 1]
+      lastItem.Documents = lastItem.Documents || []
+      lastItem.Documents.push(document)
+    }
+
+    return this
+  }
+
+  withOnlyDocument(documentCode, documentReference, overrides = {}) {
+    if (this.templateType !== 'clearance') {
+      throw new Error(
+        `withOnlyDocument is only supported for clearance requests`
+      )
+    }
+
+    const document = {
+      DocumentCode: documentCode,
+      DocumentReference: documentReference,
+      ...overrides
+    }
+
+    // Replace documents in the last item if it exists, otherwise create a new item
+    if (this.items.length === 0) {
+      this.addItem({ Documents: [document] })
+    } else {
+      const lastItem = this.items[this.items.length - 1]
+      lastItem.Documents = [document] // Replace all documents with just this one
+    }
+
+    return this
+  }
+
+  withCheck(checkCode, departmentCode, overrides = {}) {
+    if (this.templateType !== 'clearance') {
+      throw new Error(`withCheck is only supported for clearance requests`)
+    }
+
+    const check = {
+      CheckCode: checkCode,
+      DepartmentCode: departmentCode,
+      ...overrides
+    }
+
+    // Add to the last item if it exists, otherwise create a new item
+    if (this.items.length === 0) {
+      this.addItem({ Checks: [check] })
+    } else {
+      const lastItem = this.items[this.items.length - 1]
+      lastItem.Checks = lastItem.Checks || []
+      lastItem.Checks.push(check)
+    }
+
+    return this
+  }
+
+  withCommodity(taricCode, overrides = {}) {
+    if (this.templateType !== 'clearance') {
+      throw new Error(`withCommodity is only supported for clearance requests`)
+    }
+
+    // Add to the last item if it exists, otherwise create a new item
+    if (this.items.length === 0) {
+      this.addItem({ TaricCommodityCode: taricCode, ...overrides })
+    } else {
+      const lastItem = this.items[this.items.length - 1]
+      Object.assign(lastItem, { TaricCommodityCode: taricCode, ...overrides })
+    }
+
+    return this
+  }
+
+  withMRN(mrn) {
+    this._generatedMRN = mrn
+    return this
+  }
+
+  withEntryVersionNumber(entryVersionNumber) {
+    if (this.templateType !== 'clearance') {
+      throw new Error(
+        `withEntryVersionNumber is only supported for clearance requests`
+      )
+    }
+
+    // Store the entry version number to be used in buildModel
+    this._entryVersionNumber = entryVersionNumber
+    return this
+  }
+
+  withCorrelationId(correlationId) {
+    if (this.templateType !== 'clearance') {
+      throw new Error(
+        `withCorrelationId is only supported for clearance requests`
+      )
+    }
+
+    // Store the correlation ID to be used in buildModel
+    this._correlationId = correlationId
+    return this
   }
 }

--- a/test/utils/tradeimportsdatapiMessageHandler.js
+++ b/test/utils/tradeimportsdatapiMessageHandler.js
@@ -34,11 +34,14 @@ export async function waitForDataInAPI(
   collection,
   expectedProperties = null,
   timeout = TIMEOUT_MS,
-  interval = POLL_INTERVAL_MS
+  interval = POLL_INTERVAL_MS,
+  stabilityDuration = 0
 ) {
   const url = (ENDPOINTS[collection] || ENDPOINTS.DEFAULT)(key)
 
   let lastResponse, lastResponseText
+  let stableStartTime = null
+  let lastStableState = null
 
   try {
     await pWaitFor(
@@ -62,6 +65,9 @@ export async function waitForDataInAPI(
               lastResponse,
               lastResponseText
             })
+            // Reset stability tracking on error
+            stableStartTime = null
+            lastStableState = null
             return false
           }
 
@@ -74,17 +80,68 @@ export async function waitForDataInAPI(
             testLogger.info(lastResponseText)
           }
 
+          // Check if current state matches expected properties
+          let currentStateMatches = true
           if (expectedProperties && parsed) {
             const match = deepMatch(parsed, expectedProperties)
             if (!match) {
               testLogger.info(`Expected properties not met yet`)
-              return false
+              currentStateMatches = false
             }
+          } else if (expectedProperties && !parsed) {
+            currentStateMatches = false
           }
 
-          return true
+          // For stability checking, we need to ensure the state remains consistent
+          if (stabilityDuration > 0) {
+            const currentState = JSON.stringify(parsed)
+
+            if (currentStateMatches) {
+              if (lastStableState === null) {
+                // First time we see the expected state
+                lastStableState = currentState
+                stableStartTime = Date.now()
+                testLogger.info(
+                  `Stability check started at ${new Date(stableStartTime).toISOString()}`
+                )
+              } else if (lastStableState === currentState) {
+                // State is still the same, check if we've been stable long enough
+                const stableDuration = Date.now() - stableStartTime
+                if (stableDuration >= stabilityDuration) {
+                  testLogger.info(
+                    `State has been stable for ${stableDuration}ms (required: ${stabilityDuration}ms)`
+                  )
+                  return true
+                } else {
+                  testLogger.info(
+                    `State stable for ${stableDuration}ms, waiting for ${stabilityDuration - stableDuration}ms more`
+                  )
+                  return false
+                }
+              } else {
+                // State changed, reset stability tracking
+                testLogger.info(`State changed, resetting stability check`)
+                lastStableState = currentState
+                stableStartTime = Date.now()
+                return false
+              }
+            } else {
+              // Current state doesn't match expected properties
+              stableStartTime = null
+              lastStableState = null
+              return false
+            }
+          } else {
+            // No stability duration required, return immediately if state matches
+            return currentStateMatches
+          }
+
+          return false
         } catch (err) {
           testLogger.error({ err })
+          // Reset stability tracking on error
+          stableStartTime = null
+          lastStableState = null
           return false
         }
       },
@@ -100,4 +157,23 @@ export async function waitForDataInAPI(
     }
     throw err
   }
+}
+
+// Convenience function for waiting with stability duration
+export async function waitForDataInAPIWithStability(
+  key,
+  collection,
+  expectedProperties = null,
+  stabilityDuration = 30000,
+  timeout = TIMEOUT_MS,
+  interval = POLL_INTERVAL_MS
+) {
+  return waitForDataInAPI(
+    key,
+    collection,
+    expectedProperties,
+    timeout,
+    interval,
+    stabilityDuration
+  )
 }


### PR DESCRIPTION
1. Added missing EN-2 & EN-5 tests
2. Updated existing EN tests to use fluent way of build and making calls
3. The 'fluent*' preifx to the method names will be removed once we migrate all the tests using fluent methods