### PR TITLE
CDMS-1325: Remove TRADE_IMPORTS_DECISION_COMPARER_USER and TRADE_IMPORTS_DECISION_COMPARER_KEY

### DIFF
--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -57,8 +57,6 @@ function initGlobals() {
 
   const required = {
     ENVIRONMENT: {},
-    TRADE_IMPORTS_DECISION_COMPARER_USER: {},
-    TRADE_IMPORTS_DECISION_COMPARER_KEY: {},
     TRADE_IMPORTS_DATA_API_USER: {},
     TRADE_IMPORTS_DATA_API_KEY: {},
     ServiceBus__Notifications__ConnectionString: {},


### PR DESCRIPTION
This service has been decommissioned and we no longer require these secrets.