### PR TITLE
CDMS-1528: Make the API key conditional

### DIFF
--- a/test/utils/dataApiClient.js
+++ b/test/utils/dataApiClient.js
@@ -1,7 +1,7 @@
 const withHeaders = (headers) => ({
   Authorization: TRADE_IMPORTS_DATA_API_AUTHORIZATION_HEADER,
   'Content-Type': 'application/json',
-  'X-API-Key': CDP_API_KEY,
+  ...(CDP_API_KEY ? { 'X-API-Key': CDP_API_KEY } : {}),
   ...headers
 })
 


### PR DESCRIPTION
The tests fail when this is not set, but it only needs to be set locally.