### PR TITLE
CDMS-1528: Satisfy both chai and eslint

### DIFF
--- a/test/scenarios/TracesCheds/TC-2.js
+++ b/test/scenarios/TracesCheds/TC-2.js
@@ -35,7 +35,7 @@ describe('BTMS receives an update to an existing TRACES CHED - TC-2', function (
     const existing = await dataApiClientGetTracesChed(this.docRef)
     const etag = existing.headers.get('etag')
 
-    expect(etag).to.not.be.null()
+    expect(etag).to.not.equal(null)
 
     const before = JSON.parse(await existing.text())
     expect(getGrossWeight(before)).to.equal('100')


### PR DESCRIPTION
Eslint did not like the function without braces, and chai does not like it with.